### PR TITLE
fix controllerimp

### DIFF
--- a/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApi.mustache
+++ b/modules/swagger-codegen/src/main/resources/JavaPlayFramework/newApi.mustache
@@ -15,23 +15,25 @@ import javax.validation.constraints.*;
 {{#operations}}
 public class {{classname}}ControllerImp {{#useInterfaces}}implements {{classname}}ControllerImpInterface{{/useInterfaces}} {
 
+    {{#examples}}
     private final ObjectMapper mapper;
 
     @Inject
     private {{classname}}ControllerImp() {
         mapper = new ObjectMapper();
     }
+    {{/examples}}
 
 {{#operation}}
     {{#useInterfaces}}@Override{{/useInterfaces}}
     public {{>returnTypes}} {{operationId}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{>formParams}}{{>headerParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {{#handleExceptions}}throws Exception{{/handleExceptions}} {
         //Do your magic!!!
-        {{#examples}}
-        String accept = request().getHeader("Accept");
+        {{!examples}}
+        /*String accept = request().getHeader("Accept"); }}
         if (accept != null && accept.contains("{{{contentType}}}")) {
             return mapper.readValue("{{#lamdaRemoveLineBreak}}{{#lamdaEscapeDoubleQuote}}{{{example}}}{{/lamdaEscapeDoubleQuote}}{{/lamdaRemoveLineBreak}}", {{>exampleReturnTypes}}.class);
-        }
-        {{/examples}}
+        }*/
+        {{!examples}}
         {{#returnType}}{{#isResponseFile}}return new FileInputStream("replace this");{{/isResponseFile}}{{^isResponseFile}}return new {{>returnTypesNoVoidNoAbstract}}();{{/isResponseFile}}{{/returnType}}
     }
 


### PR DESCRIPTION
Disable temporary the logic in the implementation since it does not work

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [x] Filed the PR against the correct branch: master for non-breaking changes and `3.0.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

put the constructor as optional if examples is set and disable temporally the logic for example in the method since it is giving problems

